### PR TITLE
Support all bullfrog-central.properties to be passed from env variabl…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD ./entrypoint.sh /entrypoint.sh
 ADD ./logback.xml /bullfrog-central/logback.xml
 
 
-RUN curl -L "https://bintray.com/thefreebit-org/projects/download_file?file_path=thefreebit%2Fbullfrog-central%2F0.0.2%2Fbullfrog-central-0.0.2.zip" -o installer.zip
+RUN curl -L "https://bintray.com/thefreebit-org/projects/download_file?file_path=thefreebit%2Fbullfrog-central%2F${BULLFROG_VERSION}%2Fbullfrog-central-0.0.2.zip" -o installer.zip
 
 RUN unzip installer.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM openjdk:8u151-jdk
-ARG BULLFROG_VERSION=0.0.0
+ARG BULLFROG_VERSION=0.0.2
 
 ADD ./entrypoint.sh /entrypoint.sh
+ADD ./logback.xml /bullfrog-central/logback.xml
 
 
-RUN curl -L "https://bintray.com/thefreebit-org/projects/download_file?file_path=thefreebit%2Fbullfrog-central%2F${BULLFROG_VERSION}%2Fbullfrog-central-${BULLFROG_VERSION}.zip" -o installer.zip
+RUN curl -L "https://bintray.com/thefreebit-org/projects/download_file?file_path=thefreebit%2Fbullfrog-central%2F0.0.2%2Fbullfrog-central-0.0.2.zip" -o installer.zip
 
 RUN unzip installer.zip
+
+RUN apt-get update && apt-get install -y vim telnet
 
 RUN cp /bullfrog-central/bullfrog-central.properties /bullfrog-central/bullfrog-central.properties.original
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,20 @@ populatePropertyIfNeeded() {
     then
         local PROP=$(quoteSubst "$1")
         local VAL=$(quoteSubst "$2")
-        sed -ri.bak "s/^${PROP}=/${PROP}=$VAL/g" bullfrog-central.properties
+        sed -ri "s/^${PROP}=/${PROP}=$VAL/g" bullfrog-central.properties
+    fi
+}
+
+populateLogIfNeeded() {
+    if [[ "$2" ]]
+    then
+        local PROP=$(quoteSubst "$1")
+        local VAL=$(quoteSubst "$2")
+        sed -ri "s/${PROP}/$VAL/g" logback.xml
+    else
+        local PROP=$(quoteSubst "$1")
+        local VAL="info"
+	sed -ri "s/${PROP}/$VAL/g" logback.xml
     fi
 }
 
@@ -35,6 +48,20 @@ populatePropertyIfNeeded "cassandra.contactPoints" $CASSANDRA_URL
 populatePropertyIfNeeded "cassandra.username" $CASSANDRA_USERNAME
 populatePropertyIfNeeded "cassandra.password" $CASSANDRA_PASSWORD
 populatePropertyIfNeeded "cassandra.keyspace" $CASSANDRA_KEYSPACE
-populatePropertyIfNeeded "cassandra.contactPoints" $CASSANDRA_CONSISTENCY
+populatePropertyIfNeeded "cassandra.consistencyLevel" $CASSANDRA_CONSISTENCY
+populatePropertyIfNeeded "grpc.bindAddress" $GRPC_BIND
+populatePropertyIfNeeded "grpc.httpPort" $GRPC_HTTP_PORT
+populatePropertyIfNeeded "grpc.httpsPort" $GRPC_HTTPS_PORT
+populatePropertyIfNeeded "ui.bindAddress" $UI_BIND
+populatePropertyIfNeeded "ui.port" $UI_PORT
+populatePropertyIfNeeded "ui.https" $UI_HTTPS
+populatePropertyIfNeeded "ui.contextPath" $UI_CONTEXT
 
-java -jar ${JAVA_OPTS} bullfrog-central.jar
+populateLogIfNeeded "LOG_LEVEL" $LOG_LEVEL
+
+if [ -z ${JAVA_OPTS} ]
+then
+	java -jar -Dlogback.configurationFile=/bullfrog-central/logback.xml bullfrog-central.jar
+else
+	java -jar ${JAVA_OPTS} -Dlogback.configurationFile=/bullfrog-central/logback.xml bullfrog-central.jar
+fi

--- a/logback.xml
+++ b/logback.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration debug="false" scan="true">
+
+  <!-- to edit this file, copy it to the glowroot-central folder (where glowroot-central.jar
+    resides), keeping the same file name (logback.xml), and glowroot-central will find it and use it
+    instead of the logback.xml configuration file that is inside glowroot-central.jar -->
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${glowroot.log.dir}/glowroot-central.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern>${glowroot.log.dir}/glowroot-central.%i.log</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>10</maxIndex>
+    </rollingPolicy>
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>10MB</maxFileSize>
+    </triggeringPolicy>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator" />
+  <root level="LOG_LEVEL">
+    <!-- use -Dglowroot.log.consoleOff=true to turn off console logging -->
+    <if condition="p(&quot;glowroot.log.consoleOff&quot;).equalsIgnoreCase(&quot;true&quot;)">
+      <else>
+        <appender-ref ref="CONSOLE" />
+      </else>
+    </if>
+    <appender-ref ref="FILE" />
+  </root>
+
+  <!-- use -Dglowroot.log.auditOn=true to turn on audit logging -->
+  <if condition="p(&quot;glowroot.log.auditOn&quot;).equalsIgnoreCase(&quot;true&quot;)">
+    <then>
+      <appender name="AUDIT"
+        class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+          <fileNamePattern>
+            ${glowroot.log.dir}/glowroot-central-audit.%d{yyyy-MM-dd}.log
+          </fileNamePattern>
+          <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+          <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %msg%n</pattern>
+        </encoder>
+      </appender>
+      <logger name="audit" level="LOG_LEVEL" additivity="false">
+        <appender-ref ref="AUDIT" />
+      </logger>
+    </then>
+    <else>
+      <logger name="audit" level="off" />
+    </else>
+  </if>
+</configuration>
+


### PR DESCRIPTION
I wanted to make logback.xml an external file so the log level could be adjusted either by environment variable or even by changing it while the container is running (therefore the scan="true") 

In addition I wanted to allow the entire bullfrog-central properties to support environment variables